### PR TITLE
Fix stimulus due to non-compile error

### DIFF
--- a/file_struc_edaplayground/testbench/stimulus.sv
+++ b/file_struc_edaplayground/testbench/stimulus.sv
@@ -148,7 +148,7 @@ endclass
 
 //Unselect next line for test
 //`define stimulus_tb
-//`ifdef stimulus_tb
+`ifdef stimulus_tb
   module tb;
     initial begin
       stimulus sti = new();


### PR DESCRIPTION
The stimulus had a macro 'endif error because its start point, 'ifdef, was commented out.